### PR TITLE
Revert "Fix focusWindow parameter name"

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -314,7 +314,7 @@ windows :: (HasCallStack, WebDriver wd) => wd [WindowHandle]
 windows = doSessCommand methodGet "/window_handles" Null
 
 focusWindow :: (HasCallStack, WebDriver wd) => WindowHandle -> wd ()
-focusWindow w = noReturn $ doSessCommand methodPost "/window" . single "handle" $ w
+focusWindow w = noReturn $ doSessCommand methodPost "/window" . single "name" $ w
 
 -- |Closes the given window
 closeWindow :: (HasCallStack, WebDriver wd) => WindowHandle -> wd ()


### PR DESCRIPTION
This reverts commit 8bc94c291838d6d4152138cf4ab94d1db6f8da7e.

Not sure why this was changed but our selenium wants 'name'